### PR TITLE
Add layout printers to the debugger and autogenerate `tools/debug_printer`

### DIFF
--- a/.depend
+++ b/.depend
@@ -993,12 +993,14 @@ typing/mtype.cmi : \
 typing/oprint.cmo : \
     parsing/pprintast.cmi \
     typing/outcometree.cmi \
+    typing/layouts.cmi \
     utils/clflags.cmi \
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmx : \
     parsing/pprintast.cmx \
     typing/outcometree.cmi \
+    typing/layouts.cmx \
     utils/clflags.cmx \
     parsing/asttypes.cmi \
     typing/oprint.cmi

--- a/.gitignore
+++ b/.gitignore
@@ -273,6 +273,7 @@ _build
 /tools/make_opcodes.ml
 /tools/caml-tex
 /tools/eventlog_metadata
+/tools/debug_printers
 
 /toplevel/byte/topeval.mli
 /toplevel/byte/trace.mli

--- a/HACKING.jst.adoc
+++ b/HACKING.jst.adoc
@@ -63,10 +63,17 @@ for types, which we can use to see the types. Here are the instructions:
 1. Use the old `Makefile`, not the new `Makefile.jst`. This is an infelicity
 we hope to fix.
 
-2. In the `tools` directory, run `make debug_printers.cmo`.
+2. In the `tools` directory, run `make debug_printers`.
 
 3. In the debugger, execute some instructions, with e.g. `run` or `step`. This forces
 the debugger to load the compiler code, required for the next
 step.
 
 4. Execute `source tools/debug_printers` to install the printers.
+
+To add a new printer, simply add a line of the form
+
+    let name = Some.Compiler.printer
+
+to `tools/debug_printers.ml`, and then run `make debug_printers` in the `tools`
+directory to regenerate the printing script.

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -328,6 +328,12 @@ endif
 clean::
 	rm -f -- caml-tex caml-tex.exe caml_tex.cm?
 
+# Debug printer script
+debug_printers: debug_printers.ml debug_printers.cmo
+	echo 'load_printer "tools/$(basename $<).cmo"' > '$@'
+	awk '{ print "install_printer Debug_printers." $$2 }' \
+	  < '$<' >> '$@'
+
 # Common stuff
 
 %.cmo: %.ml
@@ -340,7 +346,7 @@ clean::
 	$(CAMLOPT) $(COMPFLAGS) -c - $<
 
 clean::
-	rm -f *.cmo *.cmi *.cma *.dll *.so *.lib *.a
+	rm -f debug_printers *.cmo *.cmi *.cma *.dll *.so *.lib *.a
 
 CAMLDEP=$(BOOT_OCAMLC) -depend
 DEPFLAGS=-slash

--- a/tools/debug_printers
+++ b/tools/debug_printers
@@ -3,3 +3,6 @@ install_printer Debug_printers.type_expr
 install_printer Debug_printers.row_field
 install_printer Debug_printers.ident
 install_printer Debug_printers.path
+install_printer Debug_printers.sort
+install_printer Debug_printers.sort_var
+install_printer Debug_printers.layout

--- a/tools/debug_printers
+++ b/tools/debug_printers
@@ -1,8 +1,0 @@
-load_printer "tools/debug_printers.cmo"
-install_printer Debug_printers.type_expr
-install_printer Debug_printers.row_field
-install_printer Debug_printers.ident
-install_printer Debug_printers.path
-install_printer Debug_printers.sort
-install_printer Debug_printers.sort_var
-install_printer Debug_printers.layout

--- a/tools/debug_printers.ml
+++ b/tools/debug_printers.ml
@@ -1,6 +1,7 @@
-
 let type_expr = Printtyp.raw_type_expr
 let row_field = Printtyp.raw_field
 let ident = Ident.print_with_scope
 let path = Path.print
-
+let sort = Layouts.Sort.Debug_printers.t
+let sort_var = Layouts.Sort.Debug_printers.var
+let layout = Layouts.Layout.Debug_printers.t

--- a/typing/layouts.ml
+++ b/typing/layouts.ml
@@ -84,6 +84,22 @@ module Sort = struct
   and equate s1 s2 = match s1 with
     | Const c1 -> equate_sort_const s2 c1
     | Var v1 -> equate_var v1 s2
+
+  module Debug_printers = struct
+    open Format
+
+    let rec t ppf = function
+      | Var v   -> fprintf ppf "Var %a" var v
+      | Const c -> fprintf ppf (match c with
+                                | Void  -> "Void"
+                                | Value -> "Value")
+
+    and opt_t ppf = function
+      | Some s -> fprintf ppf "Some %a" t s
+      | None   -> fprintf ppf "None"
+
+    and var ppf v = fprintf ppf "{ contents = %a }" opt_t (!v)
+  end
 end
 
 type sort = Sort.t
@@ -287,6 +303,19 @@ module Layout = struct
   let can_make_void l = Void = constrain_default_void l
   let default_to_value t =
     ignore (get_defaulting ~default:Value t)
+
+  (*********************************)
+  (* debugging *)
+
+  module Debug_printers = struct
+    open Format
+
+    let t ppf : t -> unit = function
+      | Any         -> fprintf ppf "Any"
+      | Sort s      -> fprintf ppf "Sort %a" Sort.Debug_printers.t s
+      | Immediate64 -> fprintf ppf "Immediate64"
+      | Immediate   -> fprintf ppf "Immediate"
+  end
 end
 
 type layout = Layout.t

--- a/typing/layouts.mli
+++ b/typing/layouts.mli
@@ -40,6 +40,11 @@ module Sort : sig
   (** This checks for equality, and sets any variables to make two sorts
       equal, if possible *)
   val equate : t -> t -> bool
+
+  module Debug_printers : sig
+    val t : Format.formatter -> t -> unit
+    val var : Format.formatter -> var -> unit
+  end
 end
 
 type sort = Sort.t
@@ -179,6 +184,13 @@ module Layout : sig
      would be better to default to value before we actually ship. *)
 
   val default_to_value : t -> unit
+
+  (*********************************)
+  (* debugging *)
+
+  module Debug_printers : sig
+    val t : Format.formatter -> t -> unit
+  end
 end
 
 type layout = Layout.t


### PR DESCRIPTION
This improves the UX for working with the debugger